### PR TITLE
fix: specify encoding="utf-8" on credential JSON reads

### DIFF
--- a/googleai/base_analyze_media.py
+++ b/googleai/base_analyze_media.py
@@ -180,7 +180,7 @@ class BaseAnalyzeMedia(ControlNode):
             self._log(msg)
             raise FileNotFoundError(msg)
 
-        with Path(service_account_file).open() as f:
+        with Path(service_account_file).open(encoding="utf-8") as f:
             service_account_info = json.load(f)
 
         project_id = service_account_info.get("project_id")

--- a/googleai/googleai_utils.py
+++ b/googleai/googleai_utils.py
@@ -118,7 +118,7 @@ class GoogleAuthHelper:
 
                 # Try to extract project_id from config
                 try:
-                    with open(workload_identity_config) as f:
+                    with open(workload_identity_config, encoding="utf-8") as f:
                         config = json.load(f)
                         # Try to extract from service account impersonation email
                         if "service_account_impersonation" in config:
@@ -150,7 +150,7 @@ class GoogleAuthHelper:
         if service_account_file and os.path.exists(service_account_file):
             _log("🔑 Using service account file for authentication.")
             try:
-                with open(service_account_file) as f:
+                with open(service_account_file, encoding="utf-8") as f:
                     sa_data = json.load(f)
                     final_project_id = sa_data.get("project_id")
 


### PR DESCRIPTION
## Summary

- Fixes #56 — sibling fix to engine PR griptape-ai/griptape-nodes-engine#4750 (issue griptape-ai/griptape-nodes-engine#4709)
- Adds `encoding="utf-8"` to 3 reads of Google service account / workload identity JSONs that were inheriting the platform default encoding
- Prevents `'cp949' codec can't decode byte ...` crashes on Korean (and other non-UTF-8) Windows locales when the credential JSON contains non-ASCII bytes

## Files changed

- `googleai/base_analyze_media.py:183` — `Path(service_account_file).open()` → `…open(encoding="utf-8")`
- `googleai/googleai_utils.py:121` — `open(workload_identity_config) as f` → `open(workload_identity_config, encoding="utf-8") as f`
- `googleai/googleai_utils.py:153` — `open(service_account_file) as f` → `open(service_account_file, encoding="utf-8") as f`

## Test plan

- [ ] Lint/format clean (`uv run ruff check .`)
- [ ] No-op on macOS/Linux (already UTF-8 by default)
- [ ] Manual: confirm `Path.open(encoding="utf-8")` works on Korean Windows test machine, if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)